### PR TITLE
Autoscleanr additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Each account must have a `name` specified. In addition, each type of account may
 ---
 # autocleanr
 
-Monitor the PuppetDB for inactive nodes (report_timestamp < X hours) then use the cloud provider's API to verify the certname no longer exists.  Then runs custome commands to deactivate and clean the cert name.
+Monitor the PuppetDB for inactive nodes (report_timestamp < X hours) then use the cloud provider's API to verify the certname no longer exists.  Then runs custom commands to deactivate and clean the cert name.
 
 ### Run as a CronJob
 Example

--- a/README.md
+++ b/README.md
@@ -113,3 +113,70 @@ Each account must have a `name` specified. In addition, each type of account may
 | secret    | string           | AWS Secret Key |
 | regions   | array of strings | A list of regions to check for each instance. Regions are searched in the order specified |
 | attribute | string           | Optional. Defaults to `instance-id`. The name of the attribute to compare the certname against. Useful for using a tag to compare against instead of the instance id...set to `tag:Name` to compare against the `Name` tag |      
+
+---
+# autocleanr
+
+Monitor the PuppetDB for inactive nodes (report_timestamp < X hours) then use the cloud provider's API to verify the certname no longer exists.  Then runs custome commands to deactivate and clean the cert name.
+
+### Run as a CronJob
+Example
+
+```
+15 */4 * * * /usr/sbin/autocleanr > /dev/null 2>&1
+```
+
+### Configuration Options
+
+The configuration file lives at ` /etc/autosignr/autocleanr.yaml`.
+
+| Name             | Type                        | Description |
+| ---------------  | --------------------------- | ----------- |
+| logfile          | string                      | Optional. If specified, log to this file instead of STDOUT |
+| clean\_commands  | array of string             | The command sto execute to deactivate and clean node from puppet. Should contain `%s` that will be replaced with the cert name |
+| include\_filters | array of strings            | Optional.  Additional PQL filters to add to the query to find inactive nodes.  More information in below setting
+| inactive\_hours  | int                         | Number of hours before the node is considered inactive. |
+| puppetdb_host    | string                      | The Hostname for the PuppetDB node |
+| puppetdb\_protocol | string                    | The protocol to connect to puppetdb (http|https) |
+| uppetdb\_ignore\_cert\_errors | boolean        | Set to true if you want to ignore any cert errors.  Should only be set to true in development environments |
+| puppetdb\_nodes\_uri | string                  |  The Root endpoint for the PuppetDB. |
+
+
+Example Configuration:
+
+```
+logfile: /var/log/autosignr/autocleanr.log
+clean_commands:
+  - /opt/puppetlabs/bin/puppet node deactivate %s
+  - /opt/puppetlabs/bin/puppet node clean %s
+include_filters:
+  - and facts{name = \"locations\" and value in [\"aws\"]}
+inactive_hours: 4
+puppetdb_host: puppetdb.example.com
+puppetdb_protocol: https
+puppetdb_ignore_cert_errors: false
+puppetdb_nodes_uri: /api/pdb/query/v4
+```
+
+#### include\_filters
+Optional setting to include additional queries to the API call to PuppetDB.  
+
+This setting currently supports [PQL](https://puppet.com/docs/puppetdb/5.2/api/query/v4/pql.html)  
+
+If include_filters is omitted:
+```
+curl -XPOST -H 'Content-Type:application/json' "http://localhost:8080/pdb/query/v4" \
+-d '{ "query": "nodes[certname]{ report_timestamp < \"2019-01-26T04:02:27Z\" }" }'
+```
+
+If you add the following to the config file  
+```
+include_filters:
+   - and facts{name = \"location\" and value in [\"aws\"]}
+```
+
+Adding the filter above results:
+```
+curl -XPOST -H 'Content-Type:application/json' "http://localhost:8080/pdb/query/v4" \
+-d '{ "query": "nodes[certname]{ report_timestamp < \"2019-01-28T04:02:27Z\" and facts{name = \"role\" and value in [\"nomad-client\"]} }" }'
+```

--- a/autocleanr.yaml
+++ b/autocleanr.yaml
@@ -6,4 +6,4 @@ inactive_hours: 2
 puppetdb_host: puppetdb.example.com
 puppetdb_protocol: https
 puppetdb_ignore_cert_errors: false
-puppetdb_nodes_uri: /api/pdb/query/v4/nodes
+puppetdb_nodes_uri: /api/pdb/query/v4

--- a/puppetdb.go
+++ b/puppetdb.go
@@ -3,38 +3,42 @@ package autosignr
 import (
 	"crypto/tls"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
+// PuppetDBNode - Returning from the API call to puppetDB
 type PuppetDBNode struct {
-	Certname string
+	Certname string `json:"certname"`
 }
 
-// Queries PuppetDB and returns the list of nodes found to be inactive, where
+// FindInactiveNodes Queries PuppetDB and returns the list of nodes found to be inactive, where
 // inactive is the last report timestamp is greater than $hours old
-func FindInactiveNodes(hours int, host string, protocol string, uri string, ignore_cert_errors bool) ([]string, error) {
-	var list []string
-
+func FindInactiveNodes(hours int, host string, protocol string, uri string, ignoreCertErrors bool, includeFilters []string) ([]string, error) {
 	t := time.Now().Add(time.Hour * time.Duration(hours*-1)).Format(time.RFC3339)
 
-	url := fmt.Sprintf("%s://%s%s?query=[\"<\",\"report_timestamp\",\"%s\"]",
-		protocol,
-		host,
-		uri,
-		t)
+	url := fmt.Sprintf("%s://%s%s", protocol, host, uri)
+
+	data := fmt.Sprintf("{ \"query\": \"nodes[certname]{ report_timestamp < \\\"%s\\\"", t)
+	for _, val := range includeFilters {
+		data = data + " " + val
+	}
+	data = data + " }\"}"
 
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: ignore_cert_errors},
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: ignoreCertErrors},
 	}
 	client := &http.Client{Transport: tr}
 
-	resp, err := client.Get(url)
+	var list []string
+	resp, err := client.Post(url, "application/json", strings.NewReader(data))
 	if err != nil {
-		fmt.Printf("Error : %s", err)
+		return list, errors.Wrap(err, "Post Error: ")
 	}
 	defer resp.Body.Close()
 
@@ -45,9 +49,8 @@ func FindInactiveNodes(hours int, host string, protocol string, uri string, igno
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	var l []PuppetDBNode
-
 	if err := json.Unmarshal(body, &l); err != nil {
-		return list, err
+		return list, errors.Wrap(err, "Unmarshal Error: ")
 	}
 
 	for _, val := range l {

--- a/puppetdb.go
+++ b/puppetdb.go
@@ -24,11 +24,11 @@ func FindInactiveNodes(hours int, host string, protocol string, uri string, igno
 
 	url := fmt.Sprintf("%s://%s%s", protocol, host, uri)
 
-	data := fmt.Sprintf("{ \"query\": \"nodes[certname]{ report_timestamp < \\\"%s\\\"", t)
-	for _, val := range includeFilters {
-		data = data + " " + val
-	}
-	data = data + " }\"}"
+	data := fmt.Sprintf(
+		"{ \"query\": \"nodes[certname]{ report_timestamp < \\\"%s\\\" %s }\"}",
+		t,
+		strings.Join(includeFilters, " "),
+	)
 
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: ignoreCertErrors},


### PR DESCRIPTION
Added support for add to the query to the PuppetDB to find certnames to cleanup.  This is optional.

Removed the regex on the certname since certname doesn't have to match the instance-id.  The acct.Check(certname) uses the `attribute` setting under accounts to match to the certname.