### PR TITLE
autocleanr support other account types

### DIFF
--- a/cmd/autocleanr/main.go
+++ b/cmd/autocleanr/main.go
@@ -70,11 +70,9 @@ func main() {
 		result := false
 
 		for _, acct := range conf.Accounts {
-			if acct.Type() == "aws" {
-				result = acct.Check(certname)
-				if result {
-					break
-				}
+			result = acct.Check(certname)
+			if result {
+				break
 			}
 		}
 


### PR DESCRIPTION
The acct.Check should be working on Azure and Google now.  Removing the contraint on the account being AWS.